### PR TITLE
Add Api documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,9 @@ end
 gem 'rails-controller-testing'
 # for pagination
 gem 'will_paginate'
-
+#for authentication
 gem 'devise'
-
+#for authorization
 gem 'cancancan'
+#for api documentation
+gem 'rswag'

--- a/Gemfile
+++ b/Gemfile
@@ -80,9 +80,9 @@ end
 gem 'rails-controller-testing'
 # for pagination
 gem 'will_paginate'
-#for authentication
+# for authentication
 gem 'devise'
-#for authorization
+# for authorization
 gem 'cancancan'
-#for api documentation
+# for api documentation
 gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     launchy (2.5.2)
       addressable (~> 2.8)
     letter_opener (1.8.1)
@@ -214,6 +216,20 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.0)
+    rswag (2.9.0)
+      rswag-api (= 2.9.0)
+      rswag-specs (= 2.9.0)
+      rswag-ui (= 2.9.0)
+    rswag-api (2.9.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.9.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.9.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.52.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -292,6 +308,7 @@ DEPENDENCIES
   rails (~> 7.0.5)
   rails-controller-testing
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   shoulda-matchers (~> 5.0)

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,13 @@
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,15 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users, controllers: { registrations: 'registrations' }
 
   root 'users#index'

--- a/spec/helpers/api/v1/comments_helper_spec.rb
+++ b/spec/helpers/api/v1/comments_helper_spec.rb
@@ -1,15 +1,52 @@
-require 'rails_helper'
+require 'swagger_helper'
 
-# Specs in this file have access to a helper object that includes
-# the Api::V1::CommentsHelper. For example:
-#
-# describe Api::V1::CommentsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
-RSpec.describe Api::V1::CommentsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'api/comment', type: :request do
+  path '/api/users/{user_id}/posts/{post_id}/comments' do
+    # You'll want to customize the parameter types...
+    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+    parameter name: 'post_id', in: :path, type: :string, description: 'post_id'
+
+    get('list comments') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+        let(:post_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/posts/{post_id}/comments' do
+    # You'll want to customize the parameter types...
+    parameter name: 'post_id', in: :path, type: :string, description: 'post_id'
+
+    post 'Creates a comments' do
+      tags 'Comments'
+      consumes 'application/json', 'application/xml'
+      parameter name: :comment, in: :body, schema: {
+        type: :object,
+        properties: {
+          text: { type: :string }
+        },
+        required: ['text']
+      }
+
+      response '201', 'Comments created' do
+        let(:comment) { { text: 'Hi there' } }
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:pet) { { text: 'foo' } }
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/helpers/api/v1/posts_helper_spec.rb
+++ b/spec/helpers/api/v1/posts_helper_spec.rb
@@ -1,15 +1,23 @@
-require 'rails_helper'
+require 'swagger_helper'
 
-# Specs in this file have access to a helper object that includes
-# the Api::V1::PostsHelper. For example:
-#
-# describe Api::V1::PostsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
-RSpec.describe Api::V1::PostsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'api/posts', type: :request do
+  path '/api/users/{user_id}/posts' do
+    # You'll want to customize the parameter types...
+    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+
+    get('list posts') do
+      response(200, 'successful') do
+        let(:user_id) { '10' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/requests/api/api_spec.rb
+++ b/spec/requests/api/api_spec.rb
@@ -1,0 +1,62 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/my', type: :request do
+  describe 'Blogging Haven API' do
+    path '/blogs' do
+      post 'Creates a blog' do
+        tags 'Blogs'
+        consumes 'application/json'
+        parameter name: :blog, in: :body, schema: {
+          type: :object,
+          properties: {
+            title: { type: :string },
+            content: { type: :string }
+          },
+          required: %w[title content]
+        }
+
+        response '201', 'blog created' do
+          let(:blog) { { title: 'foo', content: 'bar' } }
+          run_test!
+        end
+
+        response '422', 'invalid request' do
+          let(:blog) { { title: 'foo' } }
+          run_test!
+        end
+      end
+    end
+
+    path '/blogs/{id}' do
+      get 'Retrieves a blog' do
+        tags 'Blogs', 'Another Tag'
+        produces 'application/json', 'application/xml'
+        parameter name: :id, in: :path, type: :string
+        request_body_example value: { some_field: 'Foo' }, name: 'basic', summary: 'Request example description'
+
+        response '200', 'blog found' do
+          schema type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   title: { type: :string },
+                   content: { type: :string }
+                 },
+                 required: %w[id title content]
+
+          let(:id) { Blog.create(title: 'foo', content: 'bar').id }
+          run_test!
+        end
+
+        response '404', 'blog not found' do
+          let(:id) { 'invalid' }
+          run_test!
+        end
+
+        response '406', 'unsupported accept header' do
+          let(:Accept) { 'application/foo' }
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.configure do |config|

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,83 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/blogs":
+    post:
+      summary: Creates a blog
+      tags:
+      - Blogs
+      parameters: []
+      responses:
+        '201':
+          description: blog created
+        '422':
+          description: invalid request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                content:
+                  type: string
+              required:
+              - title
+              - content
+  "/blogs/{id}":
+    get:
+      summary: Retrieves a blog
+      tags:
+      - Blogs
+      - Another Tag
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: blog found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  title:
+                    type: string
+                  content:
+                    type: string
+                required:
+                - id
+                - title
+                - content
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  title:
+                    type: string
+                  content:
+                    type: string
+                required:
+                - id
+                - title
+                - content
+        '404':
+          description: blog not found
+        '406':
+          description: unsupported accept header
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com


### PR DESCRIPTION
### In this exercise, we followed these Instructions

 Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for our existing endpoints.
 Generate the documentation.